### PR TITLE
Feature 3: populating the syscad parameters with the values in the st…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,10 @@ venv/
 # Optional: ignore IDE files
 .vscode/
 .idea/
+
+
+# Ignore Excel and other outputs
+*.xlsx
+*.xlsm
+*.csv
+*.log

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # EquipmentDatasheetsGeneration
-# datasheet_automation
+
 This script automates the creation of the Master Equipment datasheet file and populates the sheet with the SysCAD inputs
 
 # 📊 Master Equipment Sheet Generator
@@ -7,18 +7,58 @@ This script automates the creation of the Master Equipment datasheet file and po
 This Streamlit web app allows internal users to generate a master equipment data sheet by uploading a standardized Excel workbook (`Datasheets.xlsm`). The app automatically processes and formats the data across equipment sheets and provides a timestamped Excel file ready for download.
 
 
-## 🚀 Features
+## 📋 Features
 
-- ✅ Upload Excel file (`.xlsm`) with multiple equipment sheets
-- ✅ Extracts parameters, units, and categories from each sheet
-- ✅ Groups parameters under:
+✅ Generate a clean, categorized master datasheet from your Excel `.xlsm` file.  
+✅ Populate equipment names into the master sheet by matching against the detailed streamtable.  
+✅ Populate parameter values (Flow, Temperature, Density, etc.) into the master sheet by reading from `Stream Table V` and applying aggregation & unit conversions.  
+✅ Optional verbose mode (backend-only) to debug & trace the computation step by step.  
+
+---
+
+## 🚀 Steps
+
+### Step 1: Generate Master Datasheet
+- Upload a raw `.xlsm` file with equipment-specific sheets.
+- Extracts parameters from each sheet and groups them under 5 categories:
   - SysCAD Inputs
   - Engineering Inputs
   - Lab/Pilot Inputs
-  - Project Constant
+  - Project Constants
   - Vendor Inputs
-- ✅ Merges category cells
-- ✅ Auto-sizes columns based on content
-- ✅ Applies clean border formatting to all data cells
-- ✅ Generates output with date+time stamped filename
-- ✅ Downloadable output file from the UI
+- Creates one formatted sheet per equipment with placeholders for data entry.
+- Output: `Master_DataSheet_<timestamp>.xlsx`
+
+### Step 2: Populate Equipment Names
+- Reads equipment names from your **detailed streamtable** (sheet: `Equipment & Stream List`).
+- Matches each equipment name to a sheet in the master datasheet (substring match).
+- Writes equipment names into the first available column starting at **D3** in each sheet.
+- If some equipment names could not be matched to sheets, they will appear in the skipped list.
+
+### Step 3: Populate Parameters
+- Reads the populated master sheet (from Step 2) and the same detailed streamtable.
+- Looks up streams for each equipment in `Equipment & Stream List`.
+- Finds corresponding values for each stream in `Stream Table V`.
+- Aggregates values as per rules:
+  - Sum (e.g., Flow Rate)
+  - Average (e.g., Temperature, Density)
+  - Applies unit conversions (e.g., Density × 1000).
+- Writes results into the master sheet under the respective equipment columns.
+- If some streams/parameters cannot be matched, they appear in the skipped list.
+
+---
+
+## 🐛 Debugging
+The `populate_parameters.py` function supports an optional `verbose` toggle.
+
+When `verbose=True`:
+- Prints detailed logs to the terminal:
+  - which equipment & sheet matched
+  - which streams & parameters were found
+  - what values were read
+  - what values were written and where
+  - what was skipped
+
+When deploying or in production → set `verbose=False` in `app.py`:
+```python
+result, filename, skipped = populate_parameters(master_bytes, stream_bytes, verbose=False)

--- a/app.py
+++ b/app.py
@@ -14,24 +14,22 @@ Author: Asfiya Khanam
 Created: June 2025
 
 """
-
-import streamlit as st
 from io import BytesIO
-from datetime import datetime
 import pandas as pd
+import streamlit as st
+from datetime import datetime
 
-# Backend code
 from automation_test1 import generate_master_datasheet
 from populate_equipment_names import populate_equipment_names
-
-# from populate_syscad_inputs_rev1 import populate_syscad_inputs
+from populate_parameters import populate_parameters
 
 st.title("📄 Master Equipment Datasheet Automation Tool")
 
 st.markdown("""
 This tool helps you:
 1. Generate a clean, categorized master datasheet from the Excel datasheets workbook.
-2. Populate Equipment names
+2. Populate Equipment names.
+3. Populate SysCAD parameter values.
 """)
 
 # ------------------------
@@ -53,7 +51,7 @@ st.markdown("""
 uploaded_raw = st.file_uploader("Upload your raw equipment .xlsm file", type=["xlsm"])
 if uploaded_raw and st.button("Generate Master Sheet"):
     output_stream, output_filename = generate_master_datasheet(BytesIO(uploaded_raw.read()))
-    output_stream.seek(0)  # Ensure it's at the beginning
+    output_stream.seek(0)
     st.session_state["generated_master"] = output_stream
 
     st.success("✅ Master datasheet has been successfully generated!")
@@ -65,7 +63,6 @@ if uploaded_raw and st.button("Generate Master Sheet"):
         mime="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
     )
 
-    
 # ------------------------
 # Step 2: Populate Equipment Names
 # ------------------------
@@ -77,15 +74,15 @@ st.markdown("""
 - Writes equipment names into the first available column starting at **D3**.
 """)
 
-# Check if Step 1 was completed
-use_generated = False
+use_generated_step2 = False
 if "generated_master" in st.session_state:
-    use_generated = st.radio(
+    use_generated_step2 = st.radio(
         "Choose master sheet to populate:",
-        ["Use the one generated in Step 1", "Upload a different master sheet"]
+        ["Use the one generated in Step 1", "Upload a different master sheet"],
+        key="step2_radio"
     ) == "Use the one generated in Step 1"
 
-if use_generated:
+if use_generated_step2:
     master_bytes = st.session_state["generated_master"]
 else:
     uploaded_master = st.file_uploader("Upload the master sheet", type=["xlsx"], key="master2")
@@ -97,14 +94,80 @@ else:
 uploaded_stream = st.file_uploader("Upload the detailed streamtable", type=["xlsx"], key="stream2")
 
 if master_bytes and uploaded_stream and st.button("Populate Equipment Names"):
-    stream_bytes = BytesIO(uploaded_stream.read())
+    stream_content = uploaded_stream.read()  # read bytes here
+    stream_bytes = BytesIO(stream_content)
 
     result, filename, skipped = populate_equipment_names(master_bytes, stream_bytes)
+
+    # Save outputs for Step 3
+    result.seek(0)
+    st.session_state["master_with_equipment"] = result
+    st.session_state["uploaded_stream_content"] = stream_content
 
     if skipped:
         st.warning(f"⚠️ Some equipment were not matched to any sheet:\n{', '.join(skipped)}")
 
     st.success("✅ Equipment names populated successfully.")
+
+    st.download_button(
+        label="📥 Download Populated Master Sheet",
+        data=result,
+        file_name=filename,
+        mime="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+    )
+
+# ------------------------
+# Step 3: Populate Parameter values
+# ------------------------
+st.header("Step 3: Populate Parameters")
+st.markdown("""
+**What happens in this step?**
+- Uses the populated master sheet (with equipment names from Step 2).
+- Reads equipment & stream tags from your detailed streamtable.
+- Looks up stream data in **Stream Table V**.
+- Maps & writes parameters into the master datasheet under **SysCAD Inputs** section.
+- Applies rules: sum, average, unit conversion as specified.
+""")
+
+use_generated_step3 = False
+if "master_with_equipment" in st.session_state:
+    use_generated_step3 = st.radio(
+        "Choose master sheet to populate:",
+        ["Use the one generated in Step 2", "Upload a different master sheet"],
+        key="step3_radio"
+    ) == "Use the one generated in Step 2"
+
+if use_generated_step3:
+    master_bytes = st.session_state["master_with_equipment"]
+else:
+    uploaded_master = st.file_uploader("Upload the master sheet", type=["xlsx"], key="master3")
+    if uploaded_master:
+        master_bytes = BytesIO(uploaded_master.read())
+    else:
+        master_bytes = None
+
+if "uploaded_stream_content" in st.session_state:
+    stream_bytes = BytesIO(st.session_state["uploaded_stream_content"])
+else:
+    stream_bytes = None
+
+if master_bytes and stream_bytes and st.button("Populate Parameters"):
+    result, filename, skipped = populate_parameters(master_bytes, stream_bytes)
+
+    if skipped:
+        st.warning("⚠️ Some equipment or streams could not be populated.")
+        st.text_area("Skipped Items", "\n".join(skipped), height=200)
+
+        skipped_df = pd.DataFrame(skipped, columns=["Skipped"])
+        skipped_csv = skipped_df.to_csv(index=False).encode("utf-8")
+        st.download_button(
+            label="📥 Download Skipped Items List",
+            data=skipped_csv,
+            file_name="skipped_parameters.csv",
+            mime="text/csv"
+        )
+
+    st.success("✅ Parameters populated successfully into master sheet.")
 
     st.download_button(
         label="📥 Download Populated Master Sheet",

--- a/populate_parameters.py
+++ b/populate_parameters.py
@@ -1,0 +1,161 @@
+from openpyxl import load_workbook
+import pandas as pd
+from io import BytesIO
+from datetime import datetime
+import numpy as np
+
+
+def populate_parameters(master_file, streamtable_file, verbose=False):
+    wb_master = load_workbook(master_file)
+    df_streamlist = pd.read_excel(
+        streamtable_file, sheet_name="Equipment & Stream List", header=None, engine="openpyxl"
+    )
+    df_streamtable = pd.read_excel(
+        streamtable_file, sheet_name="Stream Table V", header=6, engine="openpyxl"
+    )
+
+    skipped = []
+
+    # Build streamtable lookup
+    streamtable_lookup = {}
+    for idx, row in df_streamtable.iterrows():
+        tag = str(row.iloc[0]).strip().lower()
+        if tag:
+            streamtable_lookup[tag] = row
+
+    # updated density col_idx to 15
+    param_mapping = {
+        "Tank": {
+            "Flow Rate to/from Vessel": {
+                "col_idx": 7,  # G
+                "agg": "sum",
+                "convert": None
+            },
+            "Operating Temperature": {
+                "col_idx": 10,  # J
+                "agg": "avg",
+                "convert": None
+            },
+            "Operating Density": {
+                "col_idx": 15,  # O
+                "agg": "avg",
+                "convert": lambda x: x * 1000
+            },
+            "Design Density": {
+                "col_idx": 15,  # O
+                "agg": "avg",
+                "convert": lambda x: x * 1000
+            }
+        }
+    }
+
+    equipment_rows = df_streamlist.iloc[3:]  # from row 4
+    for _, row in equipment_rows.iterrows():
+        equip_name = str(row[0]).strip()
+        stream_tags = [str(tag).strip() for tag in row[1:5] if pd.notna(tag)]
+
+        matched_sheet = None
+        for sheet in wb_master.sheetnames:
+            if sheet.lower() in equip_name.lower():
+                matched_sheet = sheet
+                break
+
+        if not matched_sheet:
+            msg = f"[SKIP] {equip_name}: sheet not found"
+            if verbose: print(msg)
+            skipped.append(msg)
+            continue
+
+        ws = wb_master[matched_sheet]
+        equip_type = matched_sheet
+        if equip_type not in param_mapping:
+            msg = f"[SKIP] {equip_name}: no param mapping"
+            if verbose: print(msg)
+            skipped.append(msg)
+            continue
+
+        mapping = param_mapping[equip_type]
+        mapping_lc = {k.strip().lower(): v for k, v in mapping.items()}
+        collected = {k.strip().lower(): [] for k in mapping}
+
+        equip_col = None
+        for cell in ws[3]:
+            if cell.value and str(cell.value).strip().lower() == equip_name.strip().lower():
+                equip_col = cell.column
+                break
+
+        if not equip_col:
+            msg = f"[SKIP] {equip_name}: column not found"
+            if verbose: print(msg)
+            skipped.append(msg)
+            continue
+
+        if verbose:
+            print(f"\n✅ Equipment: {equip_name} → Sheet: {matched_sheet} → Column: {equip_col}")
+
+        for stream_tag in stream_tags:
+            tag_lc = stream_tag.lower()
+            if tag_lc not in streamtable_lookup:
+                msg = f"[SKIP] {equip_name}: stream '{stream_tag}' not found"
+                if verbose: print(msg)
+                skipped.append(msg)
+                continue
+
+            stream_row = streamtable_lookup[tag_lc]
+
+            for master_param, rule in mapping.items():
+                param_lc = master_param.strip().lower()
+                col_idx = rule["col_idx"]
+                try:
+                    val = stream_row.iloc[col_idx - 1]
+                    if pd.notna(val):
+                        collected[param_lc].append(float(val))
+                    if verbose:
+                        print(f" → Found value {val} for stream {stream_tag}, param {master_param} (col {col_idx})")
+                except Exception as e:
+                    msg = f"[SKIP] {equip_name}: failed reading {master_param} from stream '{stream_tag}': {e}"
+                    if verbose: print(msg)
+                    skipped.append(msg)
+
+        # Writing loop
+        for row_cells in ws.iter_rows(min_row=4, max_row=ws.max_row, min_col=1, max_col=ws.max_column):
+            category = str(row_cells[0].value).strip() if row_cells[0].value else ""
+            param_name = str(row_cells[1].value).strip() if row_cells[1].value else ""
+
+            if verbose:
+                print(f"Row {row_cells[0].row}: Category='{category}', Param='{param_name}'")
+
+            param_lc = param_name.strip().lower()
+            if param_lc in mapping_lc:
+                rule = mapping_lc[param_lc]
+                vals = collected.get(param_lc, [])
+
+                if not vals:
+                    if verbose: print(f" → No values collected for param: {param_name}")
+                    ws.cell(row=row_cells[0].row, column=equip_col).value = None
+                    continue
+
+                if rule["agg"] == "sum":
+                    result = np.nansum(vals)
+                elif rule["agg"] == "avg":
+                    result = np.nanmean(vals)
+                else:
+                    result = vals[0]
+
+                if rule["convert"]:
+                    result = rule["convert"](result)
+
+                if verbose:
+                    print(f" → Writing {round(result,2)} to cell ({row_cells[0].row},{equip_col}) for param {param_name}")
+                ws.cell(row=row_cells[0].row, column=equip_col).value = round(result, 2)
+
+            else:
+                ws.cell(row=row_cells[0].row, column=equip_col).value = None
+
+    output = BytesIO()
+    timestamp = datetime.now().strftime("%Y-%m-%d_%H-%M")
+    filename = f"Master_DataSheet_ParametersPopulated_{timestamp}.xlsx"
+    wb_master.save(output)
+    output.seek(0)
+
+    return output, filename, skipped


### PR DESCRIPTION
## ✨ Feature Summary
This PR implements **Step 3** of the Master Equipment Datasheet Automation Tool:
- Reads populated master sheet (from Step 2) and the detailed streamtable.
- Looks up equipment streams in `Equipment & Stream List`.
- Fetches corresponding parameter values from `Stream Table V`.
- Aggregates values (sum/avg) as required and applies unit conversions where applicable.
- Writes the populated parameters into the respective equipment sheet and column in the master sheet.

---

## 🧰 Key Changes
✅ New logic in `populate_parameters.py`:
- Matches equipment and streams case-insensitively.
- Reads parameters based on hardcoded column indices (instead of header strings) for reliability.
- Aggregates values across multiple streams (e.g., Flow Rate = sum, Density = avg).
- Converts units when required (e.g., density ×1000).

✅ Adds a `verbose` toggle:
- `verbose=True` → prints detailed logs for debugging.
- `verbose=False` → silent and production-ready.
- Currently set to `False` in `app.py`.

✅ Updated README.md:
- Documented Step 2 and Step 3.
- Explained the `verbose` toggle and how to enable it for debugging.

---

## 📄 Notes
- Density now correctly reads from column **15** (`O`) instead of `13`.
- `.gitignore` updated to exclude `.xlsx`, `.xlsm`, `.csv` outputs.

---

## 🔍 Testing
- Tested locally on `PopulateParameters` branch.
- Verified correct sheets and cells are populated with expected values.
- Verified skipped list logs unmatched streams and equipment.

---

## 🎯 Next Steps
- Merge into `main`.
- Tag this version as **v3** of the tool.
- Optionally deploy updated Streamlit app.

---

Closes #3 (if you have an issue tracker) or marks completion of Step 3 of the workflow.
